### PR TITLE
Fix compiling resources.c on Android-x86 kernel

### DIFF
--- a/src/resources.c
+++ b/src/resources.c
@@ -7,6 +7,7 @@
  */
 
 #include <linux/dma-mapping.h>
+#include <linux/slab.h>
 #include <linux/types.h>
 
 #include "desc.h"


### PR DESCRIPTION
Somehow they are giving implicit declaration of function error for "kzalloc" and "kfree", even though back then ipts has them in the code too.

Add slab.h to resources.c fix the issue

/media/new-ej-drive/hmtheboy154/bliss15/kernel/drivers/hid/ipts/resources.c:93:25: error: implicit declaration of function 'kzalloc' [-Werror,-Wimplicit-function-declaration]
                res->report.address = kzalloc(res->report.size, GFP_KERNEL);
                                      ^
/media/new-ej-drive/hmtheboy154/bliss15/kernel/drivers/hid/ipts/resources.c:93:23: warning: incompatible integer to pointer conversion assigning to 'u8 *' (aka 'unsigned char *') from 'int' [-Wint-conversion]
                res->report.address = kzalloc(res->report.size, GFP_KERNEL);
                                    ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/media/new-ej-drive/hmtheboy154/bliss15/kernel/drivers/hid/ipts/resources.c:127:2: error: implicit declaration of function 'kfree' [-Werror,-Wimplicit-function-declaration]
        kfree(res->report.address);
        ^
1 warning and 2 errors generated.