### PR TITLE
Inlude headers to avoid compiler warnings on 6.8

### DIFF
--- a/src/eds1.c
+++ b/src/eds1.c
@@ -11,6 +11,7 @@
 #include <linux/slab.h>
 #include <linux/types.h>
 
+#include "eds1.h"
 #include "context.h"
 #include "control.h"
 #include "spec-hid.h"

--- a/src/eds2.c
+++ b/src/eds2.c
@@ -12,6 +12,7 @@
 #include <linux/slab.h>
 #include <linux/types.h>
 
+#include "eds2.h"
 #include "context.h"
 #include "control.h"
 #include "resources.h"

--- a/src/receiver.c
+++ b/src/receiver.c
@@ -12,6 +12,7 @@
 #include <linux/timekeeping.h>
 #include <linux/types.h>
 
+#include "receiver.h"
 #include "context.h"
 #include "control.h"
 #include "hid.h"


### PR DESCRIPTION
Compiling ipts in-tree on 6.8 kernel versions with CONFIG_WERROR enabled fails due to -Wmissing-prototypes warnings in the following places:
eds1.c:19:5:ipts_eds1_get_descriptor
eds1.c:54:5:ipts_eds1_raw_request
eds2.c:29:5:ipts_eds2_get_descriptor
eds2.c:113:5:ipts_eds2_raw_request
receiver.c:175:5:ipts_receiver_start
receiver.c:192:5:ipts_receiver_stop

Including eds1.h in eds1.c, eds2.h in eds2.c and receiver.h in receiver.c obviously solves this. I am not familiar with kernel development so I don't know if it's supposed to be done like this.