### PR TITLE
increase timeout in ipts_control_wait_flush

### DIFF
--- a/src/control.c
+++ b/src/control.c
@@ -177,7 +177,7 @@ int ipts_control_wait_flush(struct ipts_context *ipts)
 	int ret = 0;
 	struct ipts_response rsp = { 0 };
 
-	ret = ipts_mei_recv(&ipts->mei, IPTS_CMD_QUIESCE_IO, &rsp);
+	ret = ipts_mei_recv_timeout(&ipts->mei, IPTS_CMD_QUIESCE_IO, &rsp, 10 * MSEC_PER_SEC);
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
This fixes a rare issue on my Surface Pro 5 (Arch Linux). Happens about every tenth boot.

log: [dmesg.txt](https://github.com/user-attachments/files/18219329/dmesg.txt)

As far as i debugged this, the module switches the mode from event to poll (see ```ipts_eds1_switch_mode```) thus calling ```ipts_control_restart```.  During shutdown the ```IPTS_CMD_QUIESCE_IO``` command sometimes times out in ```ipts_control_wait_flush``` returning ```EAGAIN``` (-11).
If the module tries to start again, the device is still "flushing" leading to the failure in ```ipts_control_get_device_info```, which obviously makes the touchscreen not working.

Increasing the timeout in ```ipts_control_wait_flush``` to 10 sec fixes this on my device, but maybe you have a nicer solution?? Alternatively we could increase the ```msleep``` timeout in ```ipts_control_restart``` but i think this PR should be the better option.